### PR TITLE
Add ability to connect with Temporal cloud

### DIFF
--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           tools: flex
-          extensions: opcache,zip,intl,pcntl,sockets,protobuf,grpc
+          extensions: opcache,zip,intl,pcntl,sockets,protobuf,grpc-1.64.1
 
       - name: Download dependencies
         env:

--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ temporal:
       namespace: default
       address: '%env(TEMPORAL_ADDRESS)%'
       dataConverter: temporal.data_converter
+    cloud:
+      namespace: default
+      address: '%env(TEMPORAL_ADDRESS)%'
+      dataConverter: temporal.data_converter
+      clientKey: '%env(TEMPORAL_CLIENT_KEY_PATH)%'
+      clientPem: '%env(TEMPORAL_CLIENT_CERT_PATH)%'
 ```
 
 

--- a/src/DependencyInjection/Compiler/ClientCompilerPass.php
+++ b/src/DependencyInjection/Compiler/ClientCompilerPass.php
@@ -55,7 +55,7 @@ final class ClientCompilerPass implements CompilerPass
             $serviceClient = definition(ServiceClient::class, [$client['address']])
                 ->setFactory([GrpcServiceClient::class, 'create']);
 
-            if ($client['clientKey'] ?? false && $client['clientPem'] ?? false) {
+            if (($client['clientKey'] ?? false) && ($client['clientPem'] ?? false)) {
                 $serviceClient = definition(ServiceClient::class, [
                     $client['address'],
                     null, // root CA - Not required for Temporal Cloud

--- a/src/DependencyInjection/Compiler/ClientCompilerPass.php
+++ b/src/DependencyInjection/Compiler/ClientCompilerPass.php
@@ -52,6 +52,9 @@ final class ClientCompilerPass implements CompilerPass
 
             $id = sprintf('temporal.%s.client', $name);
 
+            $serviceClient = definition(ServiceClient::class, [$client['address']])
+                ->setFactory([GrpcServiceClient::class, 'create']);
+
             if (isset($client['clientKey'])) {
                 $serviceClient = definition(ServiceClient::class, [
                     $client['address'],
@@ -61,9 +64,6 @@ final class ClientCompilerPass implements CompilerPass
                     null, // Overwrite server name
                 ])
                     ->setFactory([GrpcServiceClient::class, 'createSSL']);
-            } else {
-                $serviceClient = definition(ServiceClient::class, [$client['address']])
-                    ->setFactory([GrpcServiceClient::class, 'create']);
             }
 
             $container->register($id, WorkflowClient::class)

--- a/src/DependencyInjection/Compiler/ClientCompilerPass.php
+++ b/src/DependencyInjection/Compiler/ClientCompilerPass.php
@@ -55,7 +55,7 @@ final class ClientCompilerPass implements CompilerPass
             $serviceClient = definition(ServiceClient::class, [$client['address']])
                 ->setFactory([GrpcServiceClient::class, 'create']);
 
-            if (isset($client['clientKey'])) {
+            if ($client['clientKey'] ?? false && $client['clientPem'] ?? false) {
                 $serviceClient = definition(ServiceClient::class, [
                     $client['address'],
                     null, // root CA - Not required for Temporal Cloud

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -32,7 +32,7 @@ use Temporal\Api\Enums\V1\QueryRejectCondition;
  *  queryRejectionCondition: ?int,
  *  interceptors: list<non-empty-string>,
  *  clientKey: ?non-empty-string,
- *  clientCert: ?non-empty-string,
+ *  clientPem: ?non-empty-string,
  * }
  *
  * @phpstan-type ScheduleClient array{

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -30,7 +30,9 @@ use Temporal\Api\Enums\V1\QueryRejectCondition;
  *  identity: ?non-empty-string,
  *  dataConverter: non-empty-string,
  *  queryRejectionCondition: ?int,
- *  interceptors: list<non-empty-string>
+ *  interceptors: list<non-empty-string>,
+ *  clientKey: ?non-empty-string,
+ *  clientCert: ?non-empty-string,
  * }
  *
  * @phpstan-type ScheduleClient array{
@@ -125,6 +127,10 @@ final class Configuration implements BundleConfiguration
                             ->end()
                             ->scalarNode('dataConverter')
                                 ->cannotBeEmpty()->defaultValue('temporal.data_converter')
+                            ->end()
+                            ->scalarNode('clientKey')
+                            ->end()
+                            ->scalarNode('clientPem')
                             ->end()
                             ->enumNode('queryRejectionCondition')
                                 ->values([

--- a/tests/Functional/ClientTest.php
+++ b/tests/Functional/ClientTest.php
@@ -157,8 +157,6 @@ final class ClientTest extends KernelTestCase
         }]);
     }
 
-    /**
-     */
     public function testRegisterServiceClient(): void
     {
         self::bootKernel([

--- a/tests/Functional/ClientTest.php
+++ b/tests/Functional/ClientTest.php
@@ -79,6 +79,7 @@ final class ClientTest extends KernelTestCase
                     assertTrue($container->has('temporal.default.client'));
                     assertTrue($container->has('temporal.foo.client'));
                     assertTrue($container->has('temporal.bar.client'));
+                    assertTrue($container->has('temporal.cloud.client'));
                 }
             });
         }]);
@@ -98,6 +99,7 @@ final class ClientTest extends KernelTestCase
                     assertTrue($container->hasAlias('Temporal\Client\WorkflowClientInterface $defaultWorkflowClient'));
                     assertTrue($container->hasAlias('Temporal\Client\WorkflowClientInterface $fooWorkflowClient'));
                     assertTrue($container->hasAlias('Temporal\Client\WorkflowClientInterface $barWorkflowClient'));
+                    assertTrue($container->hasAlias('Temporal\Client\WorkflowClientInterface $cloudWorkflowClient'));
                 }
             });
         }]);
@@ -155,6 +157,42 @@ final class ClientTest extends KernelTestCase
         }]);
     }
 
+    /**
+     */
+    public function testRegisterServiceClient(): void
+    {
+        self::bootKernel([
+            'config' => static function (TestKernel $kernel): void {
+                $kernel->addTestBundle(TemporalBundle::class);
+                $kernel->addTestConfig(__DIR__ . '/Framework/Config/temporal.yaml');
+
+
+                $kernel->addTestCompilerPass(new class () implements CompilerPass {
+                    public function process(ContainerBuilder $container): void
+                    {
+                        /** @var Definition $def */
+                        $def = $container->getDefinition('temporal.cloud.client')
+                            ->getArgument('$serviceClient')
+                        ;
+
+                        assertInstanceOf(Definition::class, $def);
+                        assertEquals(["Temporal\Client\GRPC\ServiceClient", "createSSL"], $def->getFactory());
+                        assertCount(5, $def->getArguments());
+
+                        /** @var Definition $def */
+                        $def = $container->getDefinition('temporal.default.client')
+                            ->getArgument('$serviceClient')
+                        ;
+
+                        assertInstanceOf(Definition::class, $def);
+                        assertEquals(["Temporal\Client\GRPC\ServiceClient", "create"], $def->getFactory());
+                        assertCount(1, $def->getArguments());
+                    }
+                });
+            },
+        ]);
+    }
+
 
     /**
      * @return iterable<array{0: non-empty-string, 1: ClientOptions}>
@@ -164,8 +202,8 @@ final class ClientTest extends KernelTestCase
         yield ['temporal.default.client', ['withNamespace' => 'default', 'withIdentity' => 'default_x', 'withQueryRejectionCondition' => 0]];
         yield ['temporal.foo.client', ['withNamespace' => 'foo', 'withIdentity' => 'foo_x', 'withQueryRejectionCondition' => 1]];
         yield ['temporal.bar.client', ['withNamespace' => 'bar', 'withIdentity' => 'bar_x', 'withQueryRejectionCondition' => 2]];
+        yield ['temporal.cloud.client', ['withNamespace' => 'cloud', 'withIdentity' => 'cloud_x', 'withQueryRejectionCondition' => 2]];
     }
-
 
     public function testRegisterDefaultClient(): void
     {

--- a/tests/Functional/Framework/Config/temporal.yaml
+++ b/tests/Functional/Framework/Config/temporal.yaml
@@ -72,3 +72,12 @@ temporal:
       dataConverter: temporal.data_converter
       identity: bar_x
       queryRejectionCondition: 2
+
+    cloud:
+      namespace: cloud
+      address: '%env(TEMPORAL_ADDRESS)%'
+      dataConverter: temporal.data_converter
+      identity: cloud_x
+      queryRejectionCondition: 2
+      clientKey: '%env(TEMPORAL_CLIENT_KEY_PATH)%'
+      clientPem: '%env(TEMPORAL_CLIENT_CERT_PATH)%'


### PR DESCRIPTION
Adds the ability to connect with temporal cloud.

With cloud connection you don't actually need all the available mTLS options so I've left them out of this PR for simplicity.

Naming conventions are following what temporal has in place:

# Full mTLS example setup
https://github.com/temporalio/samples-php/tree/master/app/src/MtlsHelloWorld

# Service Client create SSL
https://github.com/temporalio/sdk-php/blob/adcfc27c9845f10194477089c39c5225bfe78608/src/Client/GRPC/BaseClient.php#L132

For full mTLS support would require adding in config options for

@param non-empty-string|null $crt Root certificates string or file in PEM format.
     *        If null provided, default gRPC root certificates are used.
    
And

@param non-empty-string|null $overrideServerName
