### PR TITLE
Allow custom factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,38 @@ temporal:
 
 
 
+## Worker Factory
 
+By default the `Temporal\WorkerFactory` is used to instantiate the workers. However when you are unit-testing you
+may wish to override the default factory with the one provided by the ['Testing framework'](https://github.com/temporalio/sdk-php/tree/master/testing)
+
+Example Config:
+
+```yaml
+temporal:
+  defaultClient: default
+  pool:
+    dataConverter: temporal.data_converter
+    roadrunnerRPC: '%env(RR_RPC)%'
+
+  workers:
+    default:
+      taskQueue: default
+      exceptionInterceptor: temporal.exception_interceptor
+      interceptors:
+        - temporal.sentry_workflow_outbound_calls.intercepto
+        - temporal.sentry_activity_inbound.interceptor
+
+  clients:
+    default:
+      namespace: default
+      address: '%env(TEMPORAL_ADDRESS)%'
+      dataConverter: temporal.data_converter
+
+when@test:
+  temporal:
+    workerFactory: Temporal\Testing\WorkerFactory
+```
 
 
 

--- a/src/DependencyInjection/Compiler/ClientCompilerPass.php
+++ b/src/DependencyInjection/Compiler/ClientCompilerPass.php
@@ -18,7 +18,6 @@ use Temporal\Client\GRPC\ServiceClient as GrpcServiceClient;
 use Temporal\Client\GRPC\ServiceClientInterface as ServiceClient;
 use Temporal\Client\WorkflowClient as GrpcWorkflowClient;
 use Temporal\Client\WorkflowClientInterface as WorkflowClient;
-
 use Temporal\Interceptor\SimplePipelineProvider;
 use Vanta\Integration\Symfony\Temporal\DependencyInjection\Configuration;
 

--- a/src/DependencyInjection/Compiler/DoctrineCompilerPass.php
+++ b/src/DependencyInjection/Compiler/DoctrineCompilerPass.php
@@ -18,7 +18,6 @@ use Symfony\Component\DependencyInjection\Reference;
 use function Vanta\Integration\Symfony\Temporal\DependencyInjection\definition;
 
 use Vanta\Integration\Symfony\Temporal\Finalizer\DoctrinePingConnectionFinalizer;
-
 use Vanta\Integration\Symfony\Temporal\InstalledVersions;
 use Vanta\Integration\Symfony\Temporal\Interceptor\DoctrineActivityInboundInterceptor;
 

--- a/src/DependencyInjection/Compiler/SentryCompilerPass.php
+++ b/src/DependencyInjection/Compiler/SentryCompilerPass.php
@@ -22,7 +22,6 @@ use function Vanta\Integration\Symfony\Temporal\DependencyInjection\definition;
 
 use Vanta\Integration\Symfony\Temporal\InstalledVersions;
 use Vanta\Integration\Temporal\Sentry\SentryActivityInboundInterceptor;
-
 use Vanta\Integration\Temporal\Sentry\SentryWorkflowOutboundCallsInterceptor;
 
 final readonly class SentryCompilerPass implements CompilerPass

--- a/src/DependencyInjection/Compiler/WorkflowCompilerPass.php
+++ b/src/DependencyInjection/Compiler/WorkflowCompilerPass.php
@@ -22,7 +22,6 @@ use Temporal\Worker\Transport\Goridge;
 use Temporal\Worker\WorkerFactoryInterface;
 use Temporal\Worker\WorkerInterface;
 use Temporal\Worker\WorkerOptions;
-use Temporal\WorkerFactory;
 
 use Vanta\Integration\Symfony\Temporal\DependencyInjection\Configuration;
 

--- a/src/DependencyInjection/Compiler/WorkflowCompilerPass.php
+++ b/src/DependencyInjection/Compiler/WorkflowCompilerPass.php
@@ -19,7 +19,8 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Temporal\Interceptor\SimplePipelineProvider;
 use Temporal\Worker\Transport\Goridge;
-use Temporal\Worker\Worker;
+use Temporal\Worker\WorkerFactoryInterface;
+use Temporal\Worker\WorkerInterface;
 use Temporal\Worker\WorkerOptions;
 use Temporal\WorkerFactory;
 
@@ -44,8 +45,8 @@ final class WorkflowCompilerPass implements CompilerPass
         /** @var RawConfiguration $config */
         $config = $container->getParameter('temporal.config');
 
-        $factory = $container->register('temporal.worker_factory', WorkerFactory::class)
-            ->setFactory([WorkerFactory::class, 'create'])
+        $factory = $container->register('temporal.worker_factory', WorkerFactoryInterface::class)
+            ->setFactory([$config["workerFactory"], 'create'])
             ->setArguments([
                 new Reference($config['pool']['dataConverter']),
                 definition(Goridge::class)
@@ -80,7 +81,7 @@ final class WorkflowCompilerPass implements CompilerPass
                 $options->addMethodCall($method, [$value], true);
             }
 
-            $newWorker = $container->register(sprintf('temporal.%s.worker', $workerName), Worker::class)
+            $newWorker = $container->register(sprintf('temporal.%s.worker', $workerName), WorkerInterface::class)
                 ->setFactory([$factory, 'newWorker'])
                 ->setArguments([
                     $worker['taskQueue'],

--- a/src/DependencyInjection/Compiler/WorkflowCompilerPass.php
+++ b/src/DependencyInjection/Compiler/WorkflowCompilerPass.php
@@ -22,7 +22,6 @@ use Temporal\Worker\Transport\Goridge;
 use Temporal\Worker\WorkerFactoryInterface;
 use Temporal\Worker\WorkerInterface;
 use Temporal\Worker\WorkerOptions;
-
 use Vanta\Integration\Symfony\Temporal\DependencyInjection\Configuration;
 
 use function Vanta\Integration\Symfony\Temporal\DependencyInjection\definition;
@@ -30,7 +29,6 @@ use function Vanta\Integration\Symfony\Temporal\DependencyInjection\definition;
 use Vanta\Integration\Symfony\Temporal\Environment;
 use Vanta\Integration\Symfony\Temporal\Runtime\Runtime;
 use Vanta\Integration\Symfony\Temporal\UI\Cli\ActivityDebugCommand;
-
 use Vanta\Integration\Symfony\Temporal\UI\Cli\WorkerDebugCommand;
 use Vanta\Integration\Symfony\Temporal\UI\Cli\WorkflowDebugCommand;
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -13,6 +13,7 @@ namespace Vanta\Integration\Symfony\Temporal\DependencyInjection;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface as BundleConfiguration;
 
+use Temporal\WorkerFactory;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\env;
 
 use Temporal\Api\Enums\V1\QueryRejectCondition;
@@ -68,6 +69,7 @@ use Temporal\Api\Enums\V1\QueryRejectCondition;
  * @phpstan-type RawConfiguration array{
  *  defaultClient: non-empty-string,
  *  defaultScheduleClient: non-empty-string,
+ *  workerFactory: non-empty-string,
  *  clients: array<non-empty-string, Client>,
  *  scheduleClients: array<non-empty-string, ScheduleClient>,
  *  workers: array<non-empty-string, Worker>,
@@ -92,6 +94,7 @@ final class Configuration implements BundleConfiguration
                 ->scalarNode('defaultScheduleClient')
                     ->defaultValue('default')
                 ->end()
+                ->scalarNode('workerFactory')->defaultValue(WorkerFactory::class)->end()
             ->end()
             ->children()
                 ->arrayNode('pool')

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -16,6 +16,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface as BundleConfigur
 use function Symfony\Component\DependencyInjection\Loader\Configurator\env;
 
 use Temporal\Api\Enums\V1\QueryRejectCondition;
+use Temporal\Worker\WorkerFactoryInterface;
 use Temporal\WorkerFactory;
 
 /**
@@ -69,7 +70,7 @@ use Temporal\WorkerFactory;
  * @phpstan-type RawConfiguration array{
  *  defaultClient: non-empty-string,
  *  defaultScheduleClient: non-empty-string,
- *  workerFactory: non-empty-string,
+ *  workerFactory: class-string<WorkerFactoryInterface>,
  *  clients: array<non-empty-string, Client>,
  *  scheduleClients: array<non-empty-string, ScheduleClient>,
  *  workers: array<non-empty-string, Worker>,
@@ -94,7 +95,25 @@ final class Configuration implements BundleConfiguration
                 ->scalarNode('defaultScheduleClient')
                     ->defaultValue('default')
                 ->end()
-                ->scalarNode('workerFactory')->defaultValue(WorkerFactory::class)->end()
+                ->scalarNode('workerFactory')->defaultValue(WorkerFactory::class)
+                    ->validate()
+                        ->ifTrue(static function (string $v): bool {
+                            $interfaces = class_implements($v);
+
+                            if (!$interfaces) {
+                                return true;
+                            }
+
+
+                            if ($interfaces[WorkerFactoryInterface::class] ?? false) {
+                                return false;
+                            }
+
+                            return true;
+                        })
+                        ->thenInvalid(sprintf('workerFactory does not implement interface: %s', WorkerFactoryInterface::class))
+                    ->end()
+                ->end()
             ->end()
             ->children()
                 ->arrayNode('pool')

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -13,10 +13,11 @@ namespace Vanta\Integration\Symfony\Temporal\DependencyInjection;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface as BundleConfiguration;
 
-use Temporal\WorkerFactory;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\env;
 
 use Temporal\Api\Enums\V1\QueryRejectCondition;
+
+use Temporal\WorkerFactory;
 
 /**
  * @phpstan-type PoolWorkerConfiguration array{

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -16,7 +16,6 @@ use Symfony\Component\Config\Definition\ConfigurationInterface as BundleConfigur
 use function Symfony\Component\DependencyInjection\Loader\Configurator\env;
 
 use Temporal\Api\Enums\V1\QueryRejectCondition;
-
 use Temporal\WorkerFactory;
 
 /**

--- a/src/TemporalBundle.php
+++ b/src/TemporalBundle.php
@@ -13,7 +13,6 @@ namespace Vanta\Integration\Symfony\Temporal;
 use function dirname;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Vanta\Integration\Symfony\Temporal\DependencyInjection\Compiler\ClientCompilerPass;
 use Vanta\Integration\Symfony\Temporal\DependencyInjection\Compiler\DoctrineCompilerPass;

--- a/tests/Functional/ClientTest.php
+++ b/tests/Functional/ClientTest.php
@@ -19,9 +19,7 @@ use function PHPUnit\Framework\assertInstanceOf;
 use function PHPUnit\Framework\assertTrue;
 
 use PHPUnit\Framework\Attributes\CoversClass;
-
 use PHPUnit\Framework\Attributes\DataProvider;
-
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface as CompilerPass;

--- a/tests/Functional/DoctrineTest.php
+++ b/tests/Functional/DoctrineTest.php
@@ -17,7 +17,6 @@ use function PHPUnit\Framework\assertEquals;
 use function PHPUnit\Framework\assertTrue;
 
 use PHPUnit\Framework\Attributes\CoversClass;
-
 use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface as CompilerPass;

--- a/tests/Functional/Framework/Config/temporal_with_factory.yaml
+++ b/tests/Functional/Framework/Config/temporal_with_factory.yaml
@@ -1,0 +1,84 @@
+temporal:
+  defaultClient: bar
+  workerFactory: 'Temporal\Testing\WorkerFactory'
+  pool:
+    dataConverter: temporal.data_converter
+    roadrunnerRPC: '%env(RR_RPC)%'
+
+  workers:
+    default:
+      taskQueue: default
+      exceptionInterceptor: temporal.exception_interceptor
+      maxConcurrentActivityExecutionSize: 0
+      workerActivitiesPerSecond: 0
+      maxConcurrentLocalActivityExecutionSize: 0
+      workerLocalActivitiesPerSecond: 0
+      taskQueueActivitiesPerSecond: 0
+      maxConcurrentActivityTaskPollers: 0
+      maxConcurrentWorkflowTaskExecutionSize: 0
+      maxConcurrentWorkflowTaskPollers: 0
+      enableSessionWorker: false
+      sessionResourceId: null
+      maxConcurrentSessionExecutionSize: 1000
+
+    foo:
+      taskQueue: foo
+      exceptionInterceptor: temporal.exception_interceptor
+      maxConcurrentActivityExecutionSize: 1
+      workerActivitiesPerSecond: 1
+      maxConcurrentLocalActivityExecutionSize: 1
+      workerLocalActivitiesPerSecond: 1
+      taskQueueActivitiesPerSecond: 1
+      maxConcurrentActivityTaskPollers: 1
+      maxConcurrentWorkflowTaskExecutionSize: 1
+      maxConcurrentWorkflowTaskPollers: 1
+      enableSessionWorker: true
+      sessionResourceId: resource.foo
+      maxConcurrentSessionExecutionSize: 2000
+
+    bar:
+      taskQueue: bar
+      exceptionInterceptor: temporal.exception_interceptor
+      maxConcurrentActivityExecutionSize: 2
+      workerActivitiesPerSecond: 2
+      maxConcurrentLocalActivityExecutionSize: 2
+      workerLocalActivitiesPerSecond: 2
+      taskQueueActivitiesPerSecond: 2
+      maxConcurrentActivityTaskPollers: 2
+      maxConcurrentWorkflowTaskExecutionSize: 2
+      maxConcurrentWorkflowTaskPollers: 2
+      enableSessionWorker: false
+      sessionResourceId: resource.bar
+      maxConcurrentSessionExecutionSize: 3000
+
+  clients:
+    default:
+      namespace: default
+      address: '%env(TEMPORAL_ADDRESS)%'
+      dataConverter: temporal.data_converter
+      identity: default_x
+      queryRejectionCondition: 0
+
+    foo:
+      namespace: foo
+      address: '%env(TEMPORAL_ADDRESS)%'
+      dataConverter: temporal.data_converter
+      identity: foo_x
+      queryRejectionCondition: 1
+
+
+    bar:
+      namespace: bar
+      address: '%env(TEMPORAL_ADDRESS)%'
+      dataConverter: temporal.data_converter
+      identity: bar_x
+      queryRejectionCondition: 2
+
+    cloud:
+      namespace: cloud
+      address: '%env(TEMPORAL_ADDRESS)%'
+      dataConverter: temporal.data_converter
+      identity: cloud_x
+      queryRejectionCondition: 2
+      clientKey: '%env(TEMPORAL_CLIENT_KEY_PATH)%'
+      clientPem: '%env(TEMPORAL_CLIENT_CERT_PATH)%'

--- a/tests/Functional/SentryTest.php
+++ b/tests/Functional/SentryTest.php
@@ -17,9 +17,7 @@ use function PHPUnit\Framework\assertTrue;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
-
 use Sentry\SentryBundle\SentryBundle;
-
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Bundle\MonologBundle\MonologBundle;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface as CompilerPass;

--- a/tests/Functional/WorkerTest.php
+++ b/tests/Functional/WorkerTest.php
@@ -121,7 +121,7 @@ final class WorkerTest extends KernelTestCase
             'config' => static function (TestKernel $kernel): void {
                 $kernel->addTestBundle(TemporalBundle::class);
                 $kernel->addTestConfig(__DIR__ . '/Framework/Config/temporal_with_factory.yaml');
-            }
+            },
         ]);
 
         $container = $kernel->getContainer();

--- a/tests/Functional/WorkerTest.php
+++ b/tests/Functional/WorkerTest.php
@@ -110,6 +110,33 @@ final class WorkerTest extends KernelTestCase
         assertNotNull($runtime);
         assertInstanceOf(Runtime::class, $runtime);
         assertCount(3, $runtime);
+
+        $factory = $container->get('temporal.worker_factory');
+        assertInstanceOf(\Temporal\WorkerFactory::class, $factory);
+    }
+
+    public function testRegisterWorkerWithCustomFactory(): void
+    {
+        $kernel = self::bootKernel([
+            'config' => static function (TestKernel $kernel): void {
+                $kernel->addTestBundle(TemporalBundle::class);
+                $kernel->addTestConfig(__DIR__ . '/Framework/Config/temporal_with_factory.yaml');
+            }
+        ]);
+
+        $container = $kernel->getContainer();
+
+        assertTrue($container->has('temporal.runtime'));
+
+        /** @var Runtime|null $runtime */
+        $runtime = $container->get('temporal.runtime');
+
+        assertNotNull($runtime);
+        assertInstanceOf(Runtime::class, $runtime);
+        assertCount(3, $runtime);
+
+        $factory = $container->get('temporal.worker_factory');
+        assertInstanceOf(\Temporal\Testing\WorkerFactory::class, $factory);
     }
 
 

--- a/tests/Functional/WorkerTest.php
+++ b/tests/Functional/WorkerTest.php
@@ -21,27 +21,20 @@ use function PHPUnit\Framework\assertNotNull;
 use function PHPUnit\Framework\assertTrue;
 
 use PHPUnit\Framework\Attributes\CoversClass;
-
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface as CompilerPass;
-
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\KernelInterface as Kernel;
 use Vanta\Integration\Symfony\Temporal\DependencyInjection\Compiler\WorkflowCompilerPass;
-
 use Vanta\Integration\Symfony\Temporal\DependencyInjection\Configuration;
 use Vanta\Integration\Symfony\Temporal\Runtime\Runtime;
-
 use Vanta\Integration\Symfony\Temporal\TemporalBundle;
-
 use Vanta\Integration\Symfony\Temporal\Test\Functional\Activity\ActivityAHandler;
-
 use Vanta\Integration\Symfony\Temporal\Test\Functional\Activity\ActivityBHandler;
 use Vanta\Integration\Symfony\Temporal\Test\Functional\Activity\ActivityCHandler;
 use Vanta\Integration\Symfony\Temporal\Test\Functional\Bundle\TestActivityBundle;


### PR DESCRIPTION
### WHY

To be able to use this library with the "Testing Framework" https://github.com/temporalio/sdk-php/tree/master/testing we need the ability to define a custom worker factory.

This testing factory allows activities to be mocked out for workflow testing purposes.

When implementing this PR I decided to only allow configuration of the workerFactory at the global level, i.e. all worker definitions will use the same factory, as this was a smaller change, and non-breaking, currently there is a single registered workerfactory with id: temporal.worker_factory

An alternative approach if desired would be to allow it to be configured per worker, and register temporal.`worker`.worker_factory instances.

