### PR TITLE
Fix support for multiple finalizers in Temporal SDK integration

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -85,7 +85,7 @@ use Temporal\WorkerFactory;
  *  enableSessionWorker: bool,
  *  sessionResourceId: ?non-empty-string,
  *  maxConcurrentSessionExecutionSize: int,
- *  finalizers: non-empty-array<int, non-empty-string>,
+ *  finalizers: array<int, non-empty-string>,
  *  interceptors: list<non-empty-string>,
  * }
  *

--- a/src/Finalizer/ChainFinalizer.php
+++ b/src/Finalizer/ChainFinalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vanta\Integration\Symfony\Temporal\Finalizer;
+
+final readonly class ChainFinalizer implements Finalizer
+{
+    /**
+     * @param iterable<Finalizer> $finalizers
+     */
+    public function __construct(
+        private iterable $finalizers,
+    ) {
+    }
+
+    public function finalize(): void
+    {
+        foreach ($this->finalizers as $finalizer) {
+            $finalizer->finalize();
+        }
+    }
+}

--- a/tests/Functional/DoctrineTest.php
+++ b/tests/Functional/DoctrineTest.php
@@ -93,6 +93,12 @@ final class DoctrineTest extends KernelTestCase
             $kernel->addTestConfig(__DIR__ . '/Framework/Config/temporal.yaml');
             $kernel->addTestConfig(__DIR__ . '/Framework/Config/doctrine.yaml');
 
+            $kernel->addTestCompilerPass(new class() implements CompilerPass {
+                public function process(ContainerBuilder $container): void
+                {
+                    assertTrue($container->hasDefinition('temporal.doctrine_clear_entity_manager.finalizer'));
+                }
+            });
 
             $kernel->addTestCompilerPass(new class($id, $arguments) implements CompilerPass {
                 /**

--- a/tests/Functional/Finalizers/DummyFinalizer.php
+++ b/tests/Functional/Finalizers/DummyFinalizer.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vanta\Integration\Symfony\Temporal\Test\Functional\Finalizers;
+
+use Vanta\Integration\Symfony\Temporal\Finalizer\Finalizer;
+
+class DummyFinalizer implements Finalizer
+{
+    public function finalize(): void
+    {
+    }
+}

--- a/tests/Functional/Framework/Config/temporal_with_custom_finalizers.yaml
+++ b/tests/Functional/Framework/Config/temporal_with_custom_finalizers.yaml
@@ -1,0 +1,63 @@
+services:
+  test.temporal.finalizer.dummy1:
+    class: Vanta\Integration\Symfony\Temporal\Test\Functional\Finalizers\DummyFinalizer
+  test.temporal.finalizer.dummy2:
+    class: Vanta\Integration\Symfony\Temporal\Test\Functional\Finalizers\DummyFinalizer
+
+temporal:
+  defaultClient: bar
+  pool:
+    dataConverter: temporal.data_converter
+    roadrunnerRPC: '%env(RR_RPC)%'
+
+  workers:
+    default:
+      taskQueue: default
+      exceptionInterceptor: temporal.exception_interceptor
+      finalizers:
+        - test.temporal.finalizer.dummy1
+        - test.temporal.finalizer.dummy2
+      maxConcurrentActivityExecutionSize: 0
+      workerActivitiesPerSecond: 0
+      maxConcurrentLocalActivityExecutionSize: 0
+      workerLocalActivitiesPerSecond: 0
+      taskQueueActivitiesPerSecond: 0
+      maxConcurrentActivityTaskPollers: 0
+      maxConcurrentWorkflowTaskExecutionSize: 0
+      maxConcurrentWorkflowTaskPollers: 0
+      enableSessionWorker: false
+      sessionResourceId: null
+      maxConcurrentSessionExecutionSize: 1000
+
+    foo:
+      taskQueue: foo
+      exceptionInterceptor: temporal.exception_interceptor
+      finalizers:
+        - test.temporal.finalizer.dummy2
+      maxConcurrentActivityExecutionSize: 1
+      workerActivitiesPerSecond: 1
+      maxConcurrentLocalActivityExecutionSize: 1
+      workerLocalActivitiesPerSecond: 1
+      taskQueueActivitiesPerSecond: 1
+      maxConcurrentActivityTaskPollers: 1
+      maxConcurrentWorkflowTaskExecutionSize: 1
+      maxConcurrentWorkflowTaskPollers: 1
+      enableSessionWorker: true
+      sessionResourceId: resource.foo
+      maxConcurrentSessionExecutionSize: 2000
+
+
+  clients:
+    default:
+      namespace: default
+      address: '%env(TEMPORAL_ADDRESS)%'
+      dataConverter: temporal.data_converter
+      identity: default_x
+      queryRejectionCondition: 0
+
+    foo:
+      namespace: foo
+      address: '%env(TEMPORAL_ADDRESS)%'
+      dataConverter: temporal.data_converter
+      identity: foo_x
+      queryRejectionCondition: 1

--- a/tests/Unit/Finalizer/ChainFinalizerTest.php
+++ b/tests/Unit/Finalizer/ChainFinalizerTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Unit\Finalizer;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\Exception;
+use PHPUnit\Framework\TestCase;
+use Vanta\Integration\Symfony\Temporal\Finalizer\ChainFinalizer;
+use Vanta\Integration\Symfony\Temporal\Finalizer\Finalizer;
+
+#[CoversClass(ChainFinalizer::class)]
+final class ChainFinalizerTest extends TestCase
+{
+    /**
+     * @throws Exception
+     */
+    public function testFinalizeCallsAllFinalizers(): void
+    {
+        // Create mocks for the Finalizer interface
+        $finalizer1 = $this->createMock(Finalizer::class);
+        $finalizer2 = $this->createMock(Finalizer::class);
+
+        // Expect the finalize method to be called once on each finalizer
+        $finalizer1->expects($this->once())->method('finalize');
+        $finalizer2->expects($this->once())->method('finalize');
+
+        // Create the ChainFinalizer with the mocked finalizers
+        $chainFinalizer = new ChainFinalizer([$finalizer1, $finalizer2]);
+
+        // Call the finalize method
+        $chainFinalizer->finalize();
+    }
+}


### PR DESCRIPTION
**Bug Description:**

The documentation for the package mentions that multiple finalizers can be passed. However, the `registerActivityFinalizer` method from the Temporal SDK only accepts a single finalizer. As a result, only the last loaded finalizer would be executed, contrary to the intended behavior.

**Fix:**

To resolve this, I implemented a `ChainFinalizer` class. This class allows multiple finalizers to be passed and ensures all of them are executed in sequence. Now, when calling `registerActivityFinalizer`, a `ChainFinalizer` containing all the required finalizers is passed to guarantee proper execution.

**Impact:**

This fix aligns the behavior with the documentation, allowing users to pass and execute multiple finalizers seamlessly.